### PR TITLE
Update to add_drift_flag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     readr,
     readxl,
     tibble,
-    tidyr
+    tidyr, 
+    slider
 Suggests: 
     knitr,
     AzureStor,

--- a/R/add_drift_flag.R
+++ b/R/add_drift_flag.R
@@ -8,8 +8,7 @@
 #' unlikely to represent natural environmental conditions.
 #'
 #' The function only processes optical parameters prone to biofouling:
-#' - FDOM Fluorescence
-#' - Turbidity 
+#' - Turbidity
 #' - Chl-a Fluorescence
 #'
 #' For other parameters, the function returns the dataframe unchanged.
@@ -23,13 +22,26 @@
 #' @return A data frame with the same structure as the input, but with the `flag`
 #' column updated to include "drift" for periods showing evidence of sensor drift.
 #'
+#'@details
+#' This function checks for drift in 4 rolling windows and assigns a drift flag if any of these
+#' rolling windows has a linear relationship with an R-squared value >= 0.5 for at least 1 day. The four rolling windows are:
+#' 1. 1-day window aligned to the right
+#' 2. 1-day window centered
+#' 3. 3-day window aligned to the right
+#' 4. 3-day window centered
+#'
+#' These windows are calculated using the `slider` package to efficiently compute rolling statistics.
+#' The windows are also broken up by site visits when a sensor is cleaned as we know that sensor biofouling is
+#' typically reset/stopped from a cleaning visit
+#'
+#'
 #' @examples
 #' # Examples are temporarily disabled
 #' @seealso [add_flag()]
 
 add_drift_flag <- function(df) {
   
-  if (!unique(df$parameter) %in% c("FDOM Fluorescence", "Turbidity", "Chl-a Fluorescence")) {
+  if (!unique(df$parameter) %in% c( "Turbidity", "Chl-a Fluorescence")) {
     return(df)
   }
   
@@ -41,43 +53,48 @@ add_drift_flag <- function(df) {
   
   # Progressive drift helper
   progressive_drift <- function(x) {
+    #Don't calculate if there are less than 10 points or less than 90% of data is present
+    if(length(x) < 10) return(0)
     if (sum(!is.na(x)) < ceiling(0.9 * length(x))) return(0)
-    
+    #Compute linear model & extract slope
     model <- lm(x ~ seq_along(x), na.action = na.omit)
     slope <- coef(model)[2]
     
-    if (param != "FDOM Fluorescence" && slope <= 0) return(0)
-    if (param == "FDOM Fluorescence" && slope >  0) return(0)
-    
+    if (slope <= 0) return(0)
+    #extract r^2
     summary(model)$r.squared
   }
   
-  # Steady drift check
-  too_steady <- function(x) mean(x, na.rm = TRUE) >= 0.60
-  
+  # Steady drift check helper (looking for when R2 is consistently high (>0.5))
+  too_steady <- function(x) mean(x, na.rm = TRUE) >= 0.5
+  # Regex to identify site visit flags
   visit_regex <- "(site\\s*visit|\\bsv\\b)"
   
   new <- df %>%
+    #Split data by site visits to avoid crossing cleaning events
     mutate(visit_group = cumsum(str_detect(replace_na(flag, ""), regex(visit_regex, ignore_case = TRUE)))) %>%
-    group_by(visit_group) %>%
+    group_by(visit_group)%>%
     # Calculate R-squared values for different window sizes and alignments
-    # 96 observations = 1 day at 15-minute intervals
-    # 288 observations = 3 days at 15-minute intervals
+    # 1 day = 1440 minutes
+    # 3 days = 4320 minutes
     dplyr::mutate(
       # 1-day windows with different alignments
-      r2_s_right = data.table::frollapply(mean, n = 96, FUN = progressive_drift, align = "right", fill = NA),
-      r2_s_center = data.table::frollapply(mean, n = 96, FUN = progressive_drift, align = "left", fill = NA),
+      r2_s_right = slider::slide_index_dbl(.x = mean, .i = DT_round, .f = progressive_drift, .before = minutes(1440)),
+      r2_s_center = slider::slide_index_dbl(.x = mean, .i = DT_round, .f = progressive_drift, .before = minutes(720), .after = minutes(720)),
       # 3-day windows with different alignments
-      r2_l_right = data.table::frollapply(mean, n = 288, FUN = progressive_drift, align = "right", fill = NA),
-      r2_l_center = data.table::frollapply(mean, n = 288, FUN = progressive_drift, align = "left", fill = NA),
+      r2_l_right = slider::slide_index_dbl(.x = mean, .i = DT_round, .f = progressive_drift, .before = minutes(4320)),
+      r2_l_center = slider::slide_index_dbl(.x = mean, .i = DT_round, .f = progressive_drift, .before = minutes(2160), .after = minutes(2160)),
       # Take the maximum R-squared from any window configuration
       tightest_r = pmax(r2_s_center, r2_s_right, r2_l_center, r2_l_right, na.rm = TRUE),
       # Check if any 1-day period has consistently high R-squared values
-      failed = data.table::frollapply(tightest_r, n = 96, FUN = too_steady, align = "right", fill = NA)) %>%
+      failed = slider::slide_index_dbl(.x = tightest_r, .i = DT_round, .before = minutes(1440), .f = too_steady)
+    ) %>%
     data.table::data.table() %>%
     # Add drift flag for periods with consistent linear trends
-    add_flag(failed == 1, "drift") %>% 
+    add_flag(failed == 1, "drift") %>%
     select(-visit_group, -r2_s_right, -r2_s_center, -r2_l_right, -r2_l_center, -tightest_r, -failed)
+  
   
   return(new)
 }
+

--- a/man/add_drift_flag.Rd
+++ b/man/add_drift_flag.Rd
@@ -27,12 +27,25 @@ unlikely to represent natural environmental conditions.
 
 The function only processes optical parameters prone to biofouling:
 \itemize{
-\item FDOM Fluorescence
 \item Turbidity
 \item Chl-a Fluorescence
 }
 
 For other parameters, the function returns the dataframe unchanged.
+}
+\details{
+This function checks for drift in 4 rolling windows and assigns a drift flag if any of these
+rolling windows has a linear relationship with an R-squared value >= 0.5 for at least 1 day. The four rolling windows are:
+\enumerate{
+\item 1-day window aligned to the right
+\item 1-day window centered
+\item 3-day window aligned to the right
+\item 3-day window centered
+}
+
+These windows are calculated using the \code{slider} package to efficiently compute rolling statistics.
+The windows are also broken up by site visits when a sensor is cleaned as we know that sensor biofouling is
+typically reset/stopped from a cleaning visit
 }
 \examples{
 # Examples are temporarily disabled


### PR DESCRIPTION
Minor revisions:
- Changing out `froll_apply` for `slider` approach so that we can use time rather the n observations for our windows. 
- Changing R2 threshold to 0.5 from 0.6
- removing fDOM from workflow as we are seems to have too high of a false positive rate
- updating `slider` to the list of packages we need